### PR TITLE
Updating role

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.yml linguist-detectable=true
+*.yaml linguist-detectable=true
+*.html linguist-detectable=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
+
 dist: focal
 language: python
-python: "3.8"
+python: "3.9"
 os: linux
 services:
   - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/clickhouse_role/tree/develop)
 
+### :hammer_and_wrench: Fixed
+
+- [#10](https://github.com/idealista/clickhouse_role/issues/10) Fix paths permissions
+- [#11](https://github.com/idealista/clickhouse_role/issues/10) Allow custom tag values for replicated macro var
+
+### :heavy_plus_sign: Added
+
+- Add .gitattributes.
+- Add option to set CH release branch version.
+
+### :repeat: Changed
+
+- Update CH default version
+- Update .travis python version to 3.9
+- Update test-requirements, ansible, molecule, etc
+- Update Readme
+
 ## [3.0.0](https://github.com/idealista/clickhouse_role/tree/3.0.0) (2021-11-23)
 
 ### :hammer_and_wrench: Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/clickhouse_role/tree/develop)
 
+## [3.0.1](https://github.com/idealista/clickhouse_role/tree/3.0.1) (2021-12-14)
+
 ### :hammer_and_wrench: Fixed
 
-- [#10](https://github.com/idealista/clickhouse_role/issues/10) Fix paths permissions
-- [#11](https://github.com/idealista/clickhouse_role/issues/10) Allow custom tag values for replicated macro var
+- [#8](https://github.com/idealista/clickhouse_role/issues/8) Remove ansible deprecation warning @Pablohn26
+- [#10](https://github.com/idealista/clickhouse_role/issues/10) Fix paths permissions @ultraheroe
+- [#11](https://github.com/idealista/clickhouse_role/issues/10) Allow custom tag values for replicated macro var @ultraheroe
 
 ### :heavy_plus_sign: Added
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,12 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-ansible = "==2.9.21"
-molecule = "==3.0.8"
-docker = "==4.1.0"
+ansible = "==4.6.0"
+molecule = "==3.5.2"
+docker = "==5.0.3"
 ansible-lint = "==5.2.1"
+molecule-containers = "==1.0.0"
+yamllint = "==1.26.3"
 
 [requires]
-python_version = "3.8"
+python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0b331184303da388f79a3912c8f3e5c2626ad28ea2364513d75d86df87eb97bb"
+            "sha256": "4141b2344f226cb33e818799c82ed8b37f0a3d11410321f1c28a1d08c2c73b17"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -18,10 +18,23 @@
     "default": {
         "ansible": {
             "hashes": [
-                "sha256:4098246b67aa143e1e3af79d99346419e0545d5405d1cdf6e7fd389beab6de5a"
+                "sha256:2955fcbf51367f8bd88c38a86f8be83d4fcd05f778afb4feed31abfe8dcff639"
             ],
             "index": "pypi",
-            "version": "==2.9.21"
+            "version": "==4.6.0"
+        },
+        "ansible-compat": {
+            "hashes": [
+                "sha256:0730fbbb32710d19f4244a4cabad9c6b33b4b92ddf72aee353484e17543405f5",
+                "sha256:3a696842689e108a827d3b60a1c32d53a546c94fe4fb244166259cbc25268c28"
+            ],
+            "version": "==0.5.0"
+        },
+        "ansible-core": {
+            "hashes": [
+                "sha256:b87188beacfac1bb6dc5cf65663f3c52e66e0f9990742db00a3dca71ebae2eee"
+            ],
+            "version": "==2.11.7"
         },
         "ansible-lint": {
             "hashes": [
@@ -59,16 +72,16 @@
         },
         "bracex": {
             "hashes": [
-                "sha256:8230f3a03f1f76c192a7844377124300fbaec83870a728b629dfabd9be9e83d0",
-                "sha256:fcd7d1ecd317c04f324dab3f40b74eb3a8409665bd397ea4279e2fbccb1a99da"
+                "sha256:096c4b788bf492f7af4e90ef8b5bcbfb99759ae3415ea1b83c9d29a5ed8f9a94",
+                "sha256:1c8d1296e00ad9a91030ccb4c291f9e4dc7c054f12c707ba3c5ff3e9a81bcd21"
             ],
-            "version": "==2.2"
+            "version": "==2.2.1"
         },
         "cerberus": {
             "hashes": [
-                "sha256:d1b21b3954b2498d9a79edf16b3170a3ac1021df88d197dc2ce5928ba519237c"
+                "sha256:302e6694f206dd85cb63f13fd5025b31ab6d38c99c50c6d769f8fa0b0f299589"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.2"
         },
         "certifi": {
             "hashes": [
@@ -141,11 +154,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
-                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
+                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.7"
+            "version": "==2.0.9"
         },
         "click": {
             "hashes": [
@@ -153,12 +166,6 @@
                 "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
             "version": "==8.0.3"
-        },
-        "click-completion": {
-            "hashes": [
-                "sha256:5bf816b81367e638a190b6e91b50779007d14301b3f9f3145d68e3cade7bce86"
-            ],
-            "version": "==0.5.2"
         },
         "click-help-colors": {
             "hashes": [
@@ -190,28 +197,29 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6",
-                "sha256:18d90f4711bf63e2fb21e8c8e51ed8189438e6b35a6d996201ebd98a26abbbe6",
-                "sha256:1ed82abf16df40a60942a8c211251ae72858b25b7421ce2497c2eb7a1cee817c",
-                "sha256:22a38e96118a4ce3b97509443feace1d1011d0571fae81fc3ad35f25ba3ea999",
-                "sha256:2d69645f535f4b2c722cfb07a8eab916265545b3475fdb34e0be2f4ee8b0b15e",
-                "sha256:4a2d0e0acc20ede0f06ef7aa58546eee96d2592c00f450c9acb89c5879b61992",
-                "sha256:54b2605e5475944e2213258e0ab8696f4f357a31371e538ef21e8d61c843c28d",
-                "sha256:7075b304cd567694dc692ffc9747f3e9cb393cc4aa4fb7b9f3abd6f5c4e43588",
-                "sha256:7b7ceeff114c31f285528ba8b390d3e9cfa2da17b56f11d366769a807f17cbaa",
-                "sha256:7eba2cebca600a7806b893cb1d541a6e910afa87e97acf2021a22b32da1df52d",
-                "sha256:928185a6d1ccdb816e883f56ebe92e975a262d31cc536429041921f8cb5a62fd",
-                "sha256:9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d",
-                "sha256:a688ebcd08250eab5bb5bca318cc05a8c66de5e4171a65ca51db6bd753ff8953",
-                "sha256:abb5a361d2585bb95012a19ed9b2c8f412c5d723a9836418fab7aaa0243e67d2",
-                "sha256:c10c797ac89c746e488d2ee92bd4abd593615694ee17b2500578b63cad6b93a8",
-                "sha256:ced40344e811d6abba00295ced98c01aecf0c2de39481792d87af4fa58b7b4d6",
-                "sha256:d57e0cdc1b44b6cdf8af1d01807db06886f10177469312fbde8f44ccbb284bc9",
-                "sha256:d99915d6ab265c22873f1b4d6ea5ef462ef797b4140be4c9d8b179915e0985c6",
-                "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad",
-                "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"
+                "sha256:2049f8b87f449fc6190350de443ee0c1dd631f2ce4fa99efad2984de81031681",
+                "sha256:231c4a69b11f6af79c1495a0e5a85909686ea8db946935224b7825cfb53827ed",
+                "sha256:24469d9d33217ffd0ce4582dfcf2a76671af115663a95328f63c99ec7ece61a4",
+                "sha256:2deab5ec05d83ddcf9b0916319674d3dae88b0e7ee18f8962642d3cde0496568",
+                "sha256:494106e9cd945c2cadfce5374fa44c94cfadf01d4566a3b13bb487d2e6c7959e",
+                "sha256:4c702855cd3174666ef0d2d13dcc879090aa9c6c38f5578896407a7028f75b9f",
+                "sha256:52f769ecb4ef39865719aedc67b4b7eae167bafa48dbc2a26dd36fa56460507f",
+                "sha256:5c49c9e8fb26a567a2b3fa0343c89f5d325447956cc2fc7231c943b29a973712",
+                "sha256:684993ff6f67000a56454b41bdc7e015429732d65a52d06385b6e9de6181c71e",
+                "sha256:6fbbbb8aab4053fa018984bb0e95a16faeb051dd8cca15add2a27e267ba02b58",
+                "sha256:8982c19bb90a4fa2aad3d635c6d71814e38b643649b4000a8419f8691f20ac44",
+                "sha256:9511416e85e449fe1de73f7f99b21b3aa04fba4c4d335d30c486ba3756e3a2a6",
+                "sha256:97199a13b772e74cdcdb03760c32109c808aff7cd49c29e9cf4b7754bb725d1d",
+                "sha256:a776bae1629c8d7198396fd93ec0265f8dd2341c553dc32b976168aaf0e6a636",
+                "sha256:aa94d617a4cd4cdf4af9b5af65100c036bce22280ebb15d8b5262e8273ebc6ba",
+                "sha256:b17d83b3d1610e571fedac21b2eb36b816654d6f7496004d6a0d32f99d1d8120",
+                "sha256:d73e3a96c38173e0aa5646c31bf8473bc3564837977dd480f5cbeacf1d7ef3a3",
+                "sha256:d91bc9f535599bed58f6d2e21a2724cb0c3895bf41c6403fe881391d29096f1d",
+                "sha256:ef216d13ac8d24d9cd851776662f75f8d29c9f2d05cdcc2d34a18d32463a9b0b",
+                "sha256:f6a5a85beb33e57998dc605b9dbe7deaa806385fdf5c4810fb849fcd04640c81",
+                "sha256:f92556f94e476c1b616e6daec5f7ddded2c082efa7cee7f31c7aeda615906ed8"
             ],
-            "version": "==35.0.0"
+            "version": "==36.0.0"
         },
         "distro": {
             "hashes": [
@@ -222,11 +230,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:6e06c5e70ba4fad73e35f00c55a895a448398f3ada7faae072e2bb01348bafc1",
-                "sha256:8f93775b8bdae3a2df6bc9a5312cce564cade58d6555f2c2570165a1270cd8a7"
+                "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0",
+                "sha256:d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==5.0.3"
         },
         "enrich": {
             "hashes": [
@@ -234,13 +242,6 @@
                 "sha256:ed0b3ac33495cc95f1ccafaf6c7ec0a0fcabb20f7f7a90121f37eb83a85bf82b"
             ],
             "version": "==1.2.6"
-        },
-        "fasteners": {
-            "hashes": [
-                "sha256:8408e52656455977053871990bd25824d85803b9417aa348f10ba29ef0c751f7",
-                "sha256:b1ab4e5adfbc28681ce44b3024421c4f567e705cc3963c732bf1cba3348307de"
-            ],
-            "version": "==0.16.3"
         },
         "idna": {
             "hashes": [
@@ -252,10 +253,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45",
-                "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"
+                "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
+                "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
             ],
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "jinja2-time": {
             "hashes": [
@@ -340,25 +341,47 @@
         },
         "molecule": {
             "hashes": [
-                "sha256:42d0c661b52074b00a620466df367ddab9c3682875e6d685bfc93487ef0479cc",
-                "sha256:6fb202099ff52bc427c6bd8f46f13b49b3d5812daa6880960a0fd0562e8a9be6"
+                "sha256:b174c2974897791e1681723d16f3744700e071f6d1e3df9cf9a07d35c6df0552",
+                "sha256:c82af099e5c0998d7eb16a3bf65ed5a4edd97e3824fb938ce01bf064a46ce0ca"
             ],
             "index": "pypi",
-            "version": "==3.0.8"
+            "version": "==3.5.2"
+        },
+        "molecule-containers": {
+            "hashes": [
+                "sha256:338d9a81e7abe804cfe66c6f3ed99237a60136773b9c42b7420633b467871e26",
+                "sha256:cb23bbec5327d6def54de26a39ab1e46999d3014b546c1d2eaa6e22a98a2a2f1"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "molecule-docker": {
+            "hashes": [
+                "sha256:e15133395f10dbf60f75125aae7145f47747fc7158f2317698885013796252bf",
+                "sha256:fc4fd84a0e98787c47b97e59bf9697bdeddfcacc67c09af271183b55e09a7d7a"
+            ],
+            "version": "==1.1.0"
+        },
+        "molecule-podman": {
+            "hashes": [
+                "sha256:9efcc2714ab60ffe11844f10c7e10ef73fa322f54bd1ecf24c41f96d61530df6",
+                "sha256:d05c407759cd61c2f0576cfe04eb9c96a1cd1f0e52283aed7e3ed3e10c97eca2"
+            ],
+            "version": "==1.0.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
-                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "version": "==21.0"
+            "version": "==21.3"
         },
         "paramiko": {
             "hashes": [
-                "sha256:def3ec612399bab4e9f5eb66b0ae5983980db9dd9120d9e9c6ea3ff673865d1c",
-                "sha256:e673b10ee0f1c80d46182d3af7751d033d9b573dd7054d2d0aa46be186c3c1d2"
+                "sha256:7b5910f5815a00405af55da7abcc8a9e0d9657f57fcdd9a89894fdbba1c6b8a8",
+                "sha256:85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438"
             ],
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "pathspec": {
             "hashes": [
@@ -367,19 +390,12 @@
             ],
             "version": "==0.9.0"
         },
-        "pexpect": {
-            "hashes": [
-                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
-                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
-            ],
-            "version": "==4.8.0"
-        },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "version": "==0.13.1"
+            "version": "==1.0.0"
         },
         "poyo": {
             "hashes": [
@@ -388,19 +404,12 @@
             ],
             "version": "==0.5.0"
         },
-        "ptyprocess": {
-            "hashes": [
-                "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35",
-                "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
-            ],
-            "version": "==0.7.0"
-        },
         "pycparser": {
             "hashes": [
-                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
-                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
             ],
-            "version": "==2.20"
+            "version": "==2.21"
         },
         "pygments": {
             "hashes": [
@@ -434,10 +443,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531",
-                "sha256:fd93fc45c47893c300bd98f5dd1b41c0e783eaeb727e7cea210dcc09d64ce7c3"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "version": "==3.0.1"
+            "version": "==3.0.6"
         },
         "python-dateutil": {
             "hashes": [
@@ -445,12 +454,6 @@
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
             "version": "==2.8.2"
-        },
-        "python-gilt": {
-            "hashes": [
-                "sha256:e220ea2e7e190ee06dbfa5fafe87967858b4ac0cf53f3072fa6ece4664a42082"
-            ],
-            "version": "==1.2.3"
         },
         "python-slugify": {
             "hashes": [
@@ -500,20 +503,27 @@
             ],
             "version": "==2.26.0"
         },
+        "resolvelib": {
+            "hashes": [
+                "sha256:123de56548c90df85137425a3f51eb93df89e2ba719aeb6a8023c032758be950",
+                "sha256:b0143b9d074550a6c5163a0f587e49c49017434e3cdfe853941725f5455dd29c"
+            ],
+            "version": "==0.5.5"
+        },
         "rich": {
             "hashes": [
-                "sha256:83fb3eff778beec3c55201455c17cccde1ccdf66d5b4dade8ef28f56b50c4bd4",
-                "sha256:c30d6808d1cd3defd56a7bd2d587d13e53b5f55de6cf587f035bcbb56bc3f37b"
+                "sha256:1dded089b79dd042b3ab5cd63439a338e16652001f0c16e73acdcf4997ad772d",
+                "sha256:43b2c6ad51f46f6c94992aee546f1c177719f4e05aff8f5ea4d2efae3ebdac89"
             ],
-            "version": "==10.12.0"
+            "version": "==10.15.2"
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:1a771fc92d3823682b7f0893ad56cb5a5c87c48e62b5399d6f42c8759a583b33",
-                "sha256:ea21da1198c4b41b8e7a259301cc9710d3b972bf8ba52f06218478e6802dd1f1"
+                "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be",
+                "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.17.16"
+            "version": "==0.17.17"
         },
         "ruamel.yaml.clib": {
             "hashes": [
@@ -550,20 +560,6 @@
             "markers": "sys_platform == 'linux'",
             "version": "==0.2.1"
         },
-        "sh": {
-            "hashes": [
-                "sha256:6f792e45b45d039b423081558904981e8ab49572b0c38009fcc65feaab06bcda",
-                "sha256:97a3d2205e3c6a842d87ebbc9ae93acae5a352b1bc4609b428d0fd5bb9e286a3"
-            ],
-            "version": "==1.13.1"
-        },
-        "shellingham": {
-            "hashes": [
-                "sha256:4855c2458d6904829bd34c299f11fdeed7cfefbf8a2c522e4caea6cd76b3171e",
-                "sha256:536b67a0697f2e4af32ab176c00a50ac2899c5a05e0d8e2dadac8e58888283f9"
-            ],
-            "version": "==1.4.0"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -571,12 +567,12 @@
             ],
             "version": "==1.16.0"
         },
-        "tabulate": {
+        "subprocess-tee": {
             "hashes": [
-                "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4",
-                "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"
+                "sha256:d34186c639aa7f8013b5dfba80e17f52589539137c9d9205f2ae1c1bd03549e1",
+                "sha256:ff5cced589a4b8ac973276ca1ba21bb6e3de600cde11a69947ff51f696efd577"
             ],
-            "version": "==0.8.9"
+            "version": "==0.3.5"
         },
         "tenacity": {
             "hashes": [
@@ -592,13 +588,6 @@
             ],
             "version": "==1.3"
         },
-        "tree-format": {
-            "hashes": [
-                "sha256:a538523aa78ae7a4b10003b04f3e1b37708e0e089d99c9d3b9e1c71384c9a7f9",
-                "sha256:b5056228dbedde1fb81b79f71fb0c23c98e9d365230df9b29af76e8d8003de11"
-            ],
-            "version": "==0.1.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
@@ -608,22 +597,23 @@
         },
         "wcmatch": {
             "hashes": [
-                "sha256:4d54ddb506c90b5a5bba3a96a1cfb0bb07127909e19046a71d689ddfb18c3617",
-                "sha256:9146b1ab9354e0797ef6ef69bc89cb32cb9f46d1b9eeef69c559aeec8f3bffb6"
+                "sha256:371072912398af61d1e4e78609e18801c6faecd3cb36c54c82556a60abc965db",
+                "sha256:7141d2c85314253f16b38cb3d6cc0fb612918d407e1df3ccc2be7c86cc259c22"
             ],
-            "version": "==8.2"
+            "version": "==8.3"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec",
-                "sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d"
+                "sha256:1315816c0acc508997eb3ae03b9d3ff619c9d12d544c9a9b553704b1cc4f6af5",
+                "sha256:2eed4cc58e4d65613ed6114af2f380f7910ff416fc8c46947f6e76b6815f56c0"
             ],
-            "version": "==1.2.1"
+            "version": "==1.2.3"
         },
         "yamllint": {
             "hashes": [
                 "sha256:3934dcde484374596d6b52d8db412929a169f6d9e52e20f9ade5bf3523d9b96e"
             ],
+            "index": "pypi",
             "version": "==1.26.3"
         }
     },

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This role has been generated using the [cookiecutter](https://github.com/cookiec
 These instructions will get you a copy of the role for your Ansible playbook. Once launched, it will install [Clickhouse](https://clickhouse.com/) in a Debian system.
 
 ### Prerequisites :ballot_box_with_check:
-Ansible 2.9.x version installed.
+
+Ansible 4.6.x version installed.
 
 Molecule 3.x.x version installed.
 
@@ -37,7 +38,7 @@ Create or add to your roles dependency file (e.g requirements.yml):
 ```yml
 - src: idealista.clickhouse_role
   scm: git
-  version: 3.0.0
+  version: 3.0.1
   name: clickhouse_role
 ```
 
@@ -80,8 +81,15 @@ $ pipenv run molecule test
 
 ## Built With :building_construction:
 
-![Ansible](https://img.shields.io/badge/ansible-2.9.21-green.svg)
-![Molecule](https://img.shields.io/badge/molecule-3.0.8-green.svg)
+ansible==4.6.0
+ansible-lint==5.2.1
+molecule==3.5.2
+docker==5.0.3
+molecule-containers==1.0.0
+yamllint==1.26.3
+
+![Ansible](https://img.shields.io/badge/ansible-4.6.0-green.svg)
+![Molecule](https://img.shields.io/badge/molecule-3.5.2-green.svg)
 ![Goss](https://img.shields.io/badge/goss-0.3.13-green.svg)
 
 ## Versioning :card_file_box:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,8 @@
 
 ## General
 # Version
-clickhouse_version: 21.11.2.2
+clickhouse_version: 21.11.5.33
+clickhouse_release_type: stable  # Values should be: stable, lts or testing
 
 ## Service options
 # Documentation
@@ -38,7 +39,7 @@ clickhouse_prerequisite_repos:
   - ca-certificates
   - dirmngr
 clickhouse_service: "clickhouse-server"
-clickhouse_deb_repo: "deb https://repo.clickhouse.tech/deb/stable/ main/" #latest stable right now, fix a version.
+clickhouse_deb_repo: "deb https://repo.clickhouse.com/deb/{{ clickhouse_release_type }}/ main/"
 clickhouse_deb_keyserver: hkp://keyserver.ubuntu.com:80
 clickhouse_deb_keyid: E0C56BD4
 clickhouse_packages:
@@ -58,9 +59,13 @@ clickhouse_users_file_name: users.xml
 # Directories
 clickhouse_base_path: "/var/lib"
 clickhouse_config_directory: "/etc/clickhouse-server"
+clickhouse_config_directory_mode: 0760
 clickhouse_log_directory: "/var/log/clickhouse-server"
+clickhouse_log_directory_mode: 0740
 clickhouse_data_directory: "{{ clickhouse_base_path }}/clickhouse"
+clickhouse_data_directory_mode: 0700
 clickhouse_tmp_directory: "{{ clickhouse_base_path }}/clickhouse/tmp"
+clickhouse_tmp_directory_mode: 0755
 clickhouse_user_files_directory: "{{ clickhouse_base_path }}/clickhouse/user_files"
 clickhouse_access_control_directory: "{{ clickhouse_base_path }}/clickhouse/access/"
 
@@ -360,9 +365,10 @@ clickhouse_remote_servers:
 #     port:
 
 # clickhouse_replicated_tables_macros:
-#   layer:
-#   shard:
-#   replica:
+#   - server: servername
+#     macro: |
+#       <shard>1</shard>
+#       <replica>1</replica>
 
 # Graphite
 # clickhouse_graphite:

--- a/molecule/default/group_vars/clickhouse_group.yml
+++ b/molecule/default/group_vars/clickhouse_group.yml
@@ -1,6 +1,6 @@
 ---
 
-clickhouse_version: 21.11.2.2
+clickhouse_version: 21.11.5.33
 
 clickhouse_admin_user: admin
 clickhouse_admin_password: admin

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -46,6 +46,7 @@
       command: "{{ goss_dst }} -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
+      ignore_errors: true
 
     - name: Display details about the Goss results
       debug:

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -14,38 +14,38 @@
     shell: /usr/sbin/nologin
     createhome: no
 
-- block:
-    - name: CLICKHOUSE | Update repositories cache and install apt-transport-https, dirmngr packages
-      apt:
-        name: "{{ clickhouse_prerequisite_repos }}"
-        state: present
-    - name: CLICKHOUSE | Be sure key is present
-      apt_key:
-        keyserver: "{{ clickhouse_deb_keyserver }}"
-        id: "{{ clickhouse_deb_keyid }}"
-        state: present
-    - name: CLICKHOUSE | Add clickhouse apt repository (deb)
-      apt_repository:
-        repo: "{{ clickhouse_deb_repo }}"
-        state: present
-    - name: CLICKHOUSE | Be sure clickhouse packages are installed (apt)
-      apt:
-        name: "{{ clickhouse_packages }}"
-        state: present
-        update_cache: true
+- name: CLICKHOUSE | Update repositories cache and install apt-transport-https, dirmngr packages
+  apt:
+    name: "{{ clickhouse_prerequisite_repos }}"
+    state: present
 
-- name: CLICKHOUSE | Ensure data directory with 0700 mode exist
+- name: CLICKHOUSE | Be sure key is present
+  apt_key:
+    keyserver: "{{ clickhouse_deb_keyserver }}"
+    id: "{{ clickhouse_deb_keyid }}"
+    state: present
+
+- name: CLICKHOUSE | Add clickhouse apt repository (deb)
+  apt_repository:
+    repo: "{{ clickhouse_deb_repo }}"
+    state: present
+
+- name: CLICKHOUSE | Be sure clickhouse packages are installed (apt)
+  apt:
+    name: "{{ clickhouse_packages }}"
+    state: present
+    update_cache: true
+
+- name: CLICKHOUSE | Ensure data directory exist
   file:
     state: directory
-    dest: "{{ item }}"
+    dest: "{{ clickhouse_data_directory }}"
     owner: "{{ clickhouse_user }}"
     group: "{{ clickhouse_group }}"
-    mode: 0700
-  with_items:
-    - "{{ clickhouse_data_directory }}"
+    mode: "{{ clickhouse_data_directory_mode }}"
   become: true
 
-- name: CLICKHOUSE | Ensure user files and access control directories with 0750 mode exist
+- name: CLICKHOUSE | Ensure user files and access control directories exist
   file:
     state: directory
     dest: "{{ item }}"
@@ -57,27 +57,31 @@
     - "{{ clickhouse_user_files_directory }}"
   become: true
 
-- name: CLICKHOUSE | Ensure needed config and tmp directories with 0755 mode exist
+- name: CLICKHOUSE | Ensure needed config directory exist
   file:
     state: directory
-    dest: "{{ item }}"
+    dest: "{{ clickhouse_config_directory }}"
     owner: "{{ clickhouse_user }}"
     group: "{{ clickhouse_group }}"
-    mode: 0755
-  with_items:
-    - "{{ clickhouse_config_directory }}"
-    - "{{ clickhouse_tmp_directory }}"
+    mode: "{{ clickhouse_config_directory_mode }}"
   become: true
 
-- name: CLICKHOUSE | Ensure needed log directory with 0775 mode exist
+- name: CLICKHOUSE | Ensure needed tmp directories exist
   file:
     state: directory
-    dest: "{{ item }}"
+    dest: "{{ clickhouse_tmp_directory }}"
     owner: "{{ clickhouse_user }}"
     group: "{{ clickhouse_group }}"
-    mode: 0775
-  with_items:
-    - "{{ clickhouse_log_directory }}"
+    mode: "{{ clickhouse_tmp_directory_mode }}"
+  become: true
+
+- name: CLICKHOUSE | Ensure needed log directory exist
+  file:
+    state: directory
+    dest: "{{ clickhouse_log_directory }}"
+    owner: "{{ clickhouse_user }}"
+    group: "{{ clickhouse_group }}"
+    mode: "{{ clickhouse_log_directory_mode }}"
   become: true
 
 - name: CLICKHOUSE | Install Clickhouse JDBC Bridge if required

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 
 - name: CLICKHOUSE | Install
-  include: "install-{{ ansible_distribution }}.yml"
+  include_tasks: "install-{{ ansible_distribution }}.yml"
   tags:
     - clickhouse_install
 
 - name: CLICKHOUSE | Configure clickhouse
-  include: config-clickhouse.yml
+  include_tasks: config-clickhouse.yml
   tags:
     - clickhouse_configure
 
 - name: CLICKHOUSE | Service
-  include: service-clickhouse.yml
+  include_tasks: service-clickhouse.yml
   tags:
     - clickhouse_service
 
 - name: CLICKHOUSE | Configure databases
-  include: config-databases.yml
+  include_tasks: config-databases.yml
   tags:
     - clickhouse_configure

--- a/templates/config.xml.j2
+++ b/templates/config.xml.j2
@@ -819,17 +819,12 @@
     <replica>example01-01-1</replica>
   </macros>
   -->
+
 {% if clickhouse_replicated_tables_macros is defined %}
   <macros>
-{% if clickhouse_replicated_tables_macros.layer is defined %}
-    <layer>{{ clickhouse_replicated_tables_macros.layer }}</layer>
-{% endif %}
-{% if clickhouse_replicated_tables_macros.shard is defined %}
-    <shard>{{ clickhouse_replicated_tables_macros.shard }}</shard>
-{% endif %}
-{% if clickhouse_replicated_tables_macros.replica is defined %}
-    <replica>{{ clickhouse_replicated_tables_macros.replica }}</replica>
-{% endif %}
+{% for macros in clickhouse_replicated_tables_macros %}
+{% if macros.server == inventory_hostname %}{{ macros.macro|indent(4, true) }}{% endif %}
+{% endfor %}
   </macros>
 {% endif %}
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,6 @@
-ansible==2.9.21
-molecule==3.0.8
-docker==4.1.0
+ansible==4.6.0
 ansible-lint==5.2.1
+molecule==3.5.2
+docker==5.0.3
+molecule-containers==1.0.0
+yamllint==1.26.3


### PR DESCRIPTION
### Description of the Change

- Remove ansible deprecation warning @Pablohn26
- clickhouse_replicated_tables_macros var now is customizable
- Fix some paths permissions
- Update ansible, molecule, etc versions
More small updates and stuff in general.

### Benefits

No more ansible deprecation warnings
clickhouse_replicated_tables_macros var tags can be custom
General CH path permissions can be customizable and set by default "more" restrictive

### Possible Drawbacks

Not known but possibly clickhouse_replicated_tables_macros var incompatibility or problems with paths?

### Applicable Issues

resolve #8 
fix #10 
fix #11 