### PR TITLE
Update macros var

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Look to the [defaults](defaults/main.yml) properties file to see the possible co
 
 ### ❗ You must know
 
+- ⚠️ `clickhouse_replicated_tables_macros` is deprecated, please use `clickhouse_macros` var
 - ⚠️ Note that are two ways to set users for ClickHouse, `users.xml` or via SQL-query, to distinguish both methods note that in this role we use `clickhouse_custom_users_xml` and `clickhouse_custom_users` respectively (SQL recommended).
 - ❗ To make us of the 'EXCEPT' clauses for [quota assignation](https://clickhouse.com/docs/en/sql-reference/statements/create/quota/) or [user grantees](https://clickhouse.com/docs/en/sql-reference/statements/create/user/#grantees) for example, you can add a minus or dash _( - )_ before the name.
 - ❗ When setting `password_type` for users, it should be one of [this](https://clickhouse.com/docs/en/sql-reference/statements/create/user/#identification)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -372,11 +372,22 @@ clickhouse_remote_servers:
 #     host:
 #     port:
 
-# clickhouse_replicated_tables_macros:
+# clickhouse_replicated_tables_macros:  # Var deprecated use clickhouse_macros
 #   - server: servername
 #     macro: |
 #       <shard>1</shard>
 #       <replica>1</replica>
+
+# Macros
+# clickhouse_macros:
+#   - macro: |
+#       <shard>1</shard>
+#       <replica>1</replica>
+#     server:
+#       - clickhouse1
+#       - clickhouse2
+#   - macro: |
+#       <db_default>default</default>
 
 # Graphite
 # clickhouse_graphite:

--- a/molecule/default/group_vars/clickhouse_group.yml
+++ b/molecule/default/group_vars/clickhouse_group.yml
@@ -118,3 +118,12 @@ clickhouse_listen_hosts:
 
 clickhouse_default_networks:
   - '::/0'
+
+clickhouse_macros:
+  - macro: |
+      <shard>1</shard>
+      <replica>1</replica>
+    server: 
+      - clickhouse
+  - macro: |
+      <db_default>default</default>

--- a/tasks/config/clickhouse.yml
+++ b/tasks/config/clickhouse.yml
@@ -7,7 +7,7 @@
     mode: 0644
   when: clickhouse_custom_config_file_path is not defined
   notify: "{{ clickhouse_handler_on_config_change }}"
-  tags: config_files
+  tags: clickhouse_configure
 
 - name: CLICKHOUSE | Add configuration files (from user files)
   copy:
@@ -18,7 +18,7 @@
     mode: 0644
   when: clickhouse_custom_config_file_path is defined
   notify: "{{ clickhouse_handler_on_config_change }}"
-  tags: config_files
+  tags: clickhouse_configure
 
 - name: CLICKHOUSE | Configure users (from vars)
   template:
@@ -28,7 +28,7 @@
   when: clickhouse_custom_users_file_path is not defined
   notify: "{{ clickhouse_handler_on_config_change }}"
   tags:
-    - config_files
+    - clickhouse_configure
     - clickhouse_users
 
 - name: CLICKHOUSE | Configure users files (from users files)
@@ -41,5 +41,5 @@
   when: clickhouse_custom_users_file_path is defined
   notify: "{{ clickhouse_handler_on_config_change }}"
   tags:
-    - config_files
+    - clickhouse_configure
     - clickhouse_users

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -65,9 +65,9 @@
     group: "{{ clickhouse_group }}"
     mode: "{{ clickhouse_config_directory_mode }}"
   with_items:
-    - clickhouse_config_directory
-    - clickhouse_config_directory_config_d
-    - clickhouse_config_directory_users_d
+    - "{{ clickhouse_config_directory }}"
+    - "{{ clickhouse_config_directory_config_d }}"
+    - "{{ clickhouse_config_directory_users_d }}"
   become: true
 
 - name: CLICKHOUSE | Ensure needed tmp directories exist

--- a/templates/config.xml.j2
+++ b/templates/config.xml.j2
@@ -833,7 +833,15 @@
   </macros>
   -->
 
-{% if clickhouse_replicated_tables_macros is defined %}
+{% if clickhouse_macros is defined %}
+  <macros>
+{% for macros in clickhouse_macros %}
+{% if macros.server is defined and inventory_hostname in macros.server %}{{ macros.macro|indent(4, true) }}{% endif %}
+{% if macros.server is not defined %}{{ macros.macro|indent(4, true) }}{% endif %}
+{% endfor %}
+  </macros>
+{# Deprecated, please use clickhouse_macros instead of clickhouse_replicated_tables_macros #}
+{% elif clickhouse_replicated_tables_macros is defined %}
   <macros>
 {% for macros in clickhouse_replicated_tables_macros %}
 {% if macros.server == inventory_hostname %}{{ macros.macro|indent(4, true) }}{% endif %}


### PR DESCRIPTION
### Description of the Change

- New macros var to deprecate clickhouse_replicated_tables_macros
- Add an example macro to molecule default scenario
- Fix config directories task existence check
- Fix tag in configure file tasks
- Update readme

### Benefits

Variable for setting macros won`t be confusing

### Possible Drawbacks

Old var for setting macros is marked as deprecated, but still works (while is being deprecated)

### Applicable Issues

#20