### PR TITLE
ldap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/clickhouse_role/tree/develop)
 
+## [3.3.4(https://github.com/idealista/clickhouse_role/tree/3.3.4 (2023-05-29)
+
+### :heavy_plus_sign: Added
+
+- [#53](https://github.com/idealista/clickhouse_role/issues/53) Add LDAP support for authentication.
+
 ## [3.3.3(https://github.com/idealista/clickhouse_role/tree/3.3.3 (2023-03-27)
 
 ### :repeat: Updated

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -246,6 +246,9 @@ clickhouse_preferserverciphers_client: true
 clickhouse_invalidcertificatehandler:
   name: RejectCertificateHandler  # Use for self-signed: AcceptCertificateHandler
 
+# Specify backend authenticacion: AD / LDAP (By default, AD)
+clickhouse_auth_backend: AD
+
 # LDAP
 # clickhouse_ldap:
 #   serverame:

--- a/templates/config.xml.j2
+++ b/templates/config.xml.j2
@@ -508,11 +508,11 @@
       {% if clickhouse_ldap.port is defined -%}<port>{{ clickhouse_ldap.port }}</port>{% endif -%}
       {% if clickhouse_ldap.bind_dn is defined -%}<bind_dn>{{ clickhouse_ldap.bind_dn }}</bind_dn>{% endif -%}
       {% if clickhouse_ldap.base_dn is defined or clickhouse_ldap.scope or clickhouse_ldap.search_filter -%}
-      <user_dn_detection>
+      {% if clickhouse_auth_backend == 'AD' -%}<user_dn_detection>{% endif -%}
         {% if clickhouse_ldap.base_dn is defined -%}<base_dn>{{ clickhouse_ldap.base_dn }}</base_dn>{% endif -%}
         {% if clickhouse_ldap.scope is defined -%}<scope>{{ clickhouse_ldap.scope }}</scope>{% endif -%}
         {% if clickhouse_ldap.search_filter is defined -%}<search_filter>{{ clickhouse_ldap.search_filter }}</search_filter>{% endif -%}
-      </user_dn_detection>
+      {% if clickhouse_auth_backend == 'AD' -%}</user_dn_detection>{% endif -%}
       {% endif -%}
       {% if clickhouse_ldap.verification_cooldown is defined -%}<verification_cooldown>{{ clickhouse_ldap.verification_cooldown }}</verification_cooldown>{% endif -%}
       {% if clickhouse_ldap.enable_tls is defined -%}<enable_tls>{{ clickhouse_ldap.enable_tls }}</enable_tls>{% endif -%}


### PR DESCRIPTION
### Requirements

### Description of the Change

Add by default a var to set AD as default auth backend. Depending on this var, especify a field in config.xml for ldap config required for AD or skip it.

### Benefits
Integration with OpenLdap

### Possible Drawbacks
None

### Applicable Issues
https://github.com/idealista/clickhouse_role/issues/53