### PR TITLE
59 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/clickhouse_role/tree/develop)
 
+## [3.3.6(https://github.com/idealista/clickhouse_role/tree/3.3.6 (2023-06-09)
+
+### :hammer_and_wrench: Fixed
+
+- [#59](https://github.com/idealista/clickhouse_role/issues/59) Fix role wiping when there are users from readonly storage
+
 ## [3.3.5(https://github.com/idealista/clickhouse_role/tree/3.3.5 (2023-06-09)
 
 ### :heavy_plus_sign: Added

--- a/tasks/config/perms_and_privs.yml
+++ b/tasks/config/perms_and_privs.yml
@@ -1,8 +1,21 @@
 ---
 
+- name: CLICKHOUSE | Get all LDAP users for grants cleaning (Optional step)
+  command: "clickhouse-client -u {{ clickhouse_admin_user }} --password {{ clickhouse_admin_password }} -q \"
+    SELECT name FROM system.users WHERE storage == 'ldap';
+    \""
+  register: ldap_user_list
+  changed_when: False
+  when: clickhouse_custom_grants_previous_cleanup
+  no_log: True
+  tags:
+    - clickhouse_grants
+    - select
+    - SQL_driven
+
 - name: CLICKHOUSE | Previous grants cleaning (Optional step)
   command: "clickhouse-client -u {{ clickhouse_admin_user }} --password {{ clickhouse_admin_password }} -q \"
-    REVOKE ALL ON *.* FROM ALL EXCEPT {{ (clickhouse_default_users | default([]) + clickhouse_admin_users | default([]) + clickhouse_custom_users_xml | default([])) | map(attribute='name') | join(', ') }};
+    REVOKE ALL ON *.* FROM ALL EXCEPT {{ ((clickhouse_default_users | default([]) + clickhouse_admin_users | default([]) + clickhouse_custom_users_xml | default([])) | map(attribute='name') | list + (ldap_user_list.stdout_lines | default([])))   | join(', ') }};
     \""
   changed_when: False
   when: clickhouse_custom_grants_previous_cleanup

--- a/tasks/config/roles.yml
+++ b/tasks/config/roles.yml
@@ -11,7 +11,7 @@
     - SQL_driven
 
 - name: CLICKHOUSE | Drop roles (SQL-driven)
-  command: "clickhouse-client -u {{ clickhouse_admin_user }} --password {{ clickhouse_admin_password }} -q \"DROP ROLE IF EXISTS {{ item }} ;\""
+  command: "clickhouse-client -u {{ clickhouse_admin_user }} --password {{ clickhouse_admin_password }} -q \"DROP ROLE IF EXISTS '{{ item }}' ;\""
   with_items: "{{ clickhouse_existing_sql_roles.stdout_lines }}"
   when:
     - clickhouse_existing_sql_roles is defined


### PR DESCRIPTION
Develop

### Requirements


### Description of the Change

Skip users coming from readonly storage when removing roles at deploy stage and allow roles with hyphens



### Applicable Issues
https://github.com/idealista/clickhouse_role/issues?q=is%3Aissue+is%3Aopen+label%3Abug
