### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: CLICKHOUSE | Install
-  include_tasks: "install-{{ ansible_distribution }}.yml"
+  include_tasks: "install-{{ ansible_os_family | capitalize }}.yml"
   tags:
     - clickhouse_install
   when: clickhouse_install_db is not defined or clickhouse_install_db


### PR DESCRIPTION
os_distribution will resolve to the actual operation system name. 
E.g.: for ubuntu, the code will try to include `install-Ubuntu.yml`

This fixes the include file for Ubuntu as well

Resolves #65 