### PR TITLE
Update role with changes in #62 and #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/clickhouse_role/tree/develop)
 
+## [3.4.0(https://github.com/idealista/clickhouse_role/tree/3.4.0 (2023-11-17)
+
+### :heavy_plus_sign: Added
+
+- [#64](https://github.com/idealista/clickhouse_role/issues/64) Add clickhouse_keeper and default replica params enhancement
+
+### :repeat: Updated
+
+- [#65](https://github.com/idealista/clickhouse_role/issues/65) Update to use ansible_os_family var instead of ansible_distribution var for main.yml
+
 ## [3.3.6(https://github.com/idealista/clickhouse_role/tree/3.3.6 (2023-06-09)
 
 ### :hammer_and_wrench: Fixed
@@ -57,7 +67,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ### :heavy_plus_sign: Added
 
-- [#35](https://github.com/idealista/clickhouse_role/issues/35) Clickhouse copier basic configuration 
+- [#35](https://github.com/idealista/clickhouse_role/issues/35) Clickhouse copier basic configuration
 
 ### :repeat: Updated
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -408,6 +408,22 @@ clickhouse_remote_servers:
             host: localhost
             port: 1
 
+# Clickhouse Keeper
+# clickhouse_keeper:
+#   tcp_port:
+#   log_storage_path:
+#   snapshot_storage_path:
+#   coordination_settings:
+#     operation_timeout_ms:
+#     session_timeout_ms:
+#     raft_logs_level:
+#   keeper_servers:
+#   - keeper_server:
+#     server:
+#     id:
+#     hostname:
+#     port:
+
 # Zookeeper
 # clickhouse_zookeeper:
 #   - node:
@@ -556,6 +572,10 @@ clickhouse_tables_log:
 #       # Key from a value / file or from ENV, use only one option.
 #       value:
 #       # from_env: ENV
+
+# Default replica params
+# clickhouse_default_replica_path:
+# clickhouse_default_replica_name:
 
 # Distributed DDL
 # clickhouse_distributed_ddl:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: CLICKHOUSE | Install
-  include_tasks: "install-{{ ansible_distribution }}.yml"
+  include_tasks: "install-{{ ansible_os_family | capitalize }}.yml"
   tags:
     - clickhouse_install
   when: clickhouse_install_db is not defined or clickhouse_install_db

--- a/templates/config.xml.j2
+++ b/templates/config.xml.j2
@@ -797,6 +797,37 @@
   Values for substitutions are specified in /clickhouse/name_of_substitution elements in that file.
   -->
 
+<!-- Clickhouse Keeper -->
+{% if clickhouse_keeper is defined %}
+{% for keeper_server in clickhouse_keeper.keeper_servers %}
+{% if keeper_server.server is defined and inventory_hostname == keeper_server.server %}
+    <keeper_server>
+        <!-- Clients use this port to connect (should match zookeeper port) -->
+        <tcp_port>{{ clickhouse_keeper.tcp_port }}</tcp_port>
+        <server_id>{{ keeper_server.id }}</server_id>
+        <log_storage_path>{{ clickhouse_keeper.log_storage_path }}</log_storage_path>
+        <snapshot_storage_path>{{ clickhouse_keeper.snapshot_storage_path }}</snapshot_storage_path>
+    
+        <coordination_settings>
+            <operation_timeout_ms>{{ clickhouse_keeper.coordination_settings.operation_timeout_ms }}</operation_timeout_ms>
+            <session_timeout_ms>{{ clickhouse_keeper.coordination_settings.session_timeout_ms }}</session_timeout_ms>
+            <raft_logs_level>{{ clickhouse_keeper.coordination_settings.raft_logs_level }}</raft_logs_level>
+        </coordination_settings>
+    
+        <raft_configuration>
+{% for keeper_server in clickhouse_keeper.keeper_servers %}
+            <server>
+                <id>{{ keeper_server.id }}</id>
+                <hostname>{{ keeper_server.hostname }}</hostname>
+                <port>{{ keeper_server.port }}</port>
+            </server>
+{% endfor %}
+        </raft_configuration>
+    </keeper_server>
+{% endif %}
+{% endfor %}
+{% endif %}
+
   <!-- ZooKeeper is used to store metadata about replicas, when using Replicated tables.
   Optional. If you don't use replicated tables, you could omit that.
   See https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/
@@ -1270,6 +1301,15 @@
     </{{ clickhouse_encryption.encryption }}>
 {% endif %}
   </encryption_codecs>
+
+  <!-- Default arguments passed to Replicated table engines -->
+{% if clickhouse_default_replica_path is defined %}
+  <default_replica_path>{{ clickhouse_default_replica_path }}</default_replica_path>
+{% endif %}
+{% if clickhouse_default_replica_name is defined %}
+  <default_replica_name>{{ clickhouse_default_replica_name }}</default_replica_name>
+{% endif %}
+
 
   <!-- Allow to execute distributed DDL queries (CREATE, DROP, ALTER, RENAME) on cluster.
     Works only if ZooKeeper is enabled. Comment it if such functionality isn't required. -->


### PR DESCRIPTION
### Description of the Change

- Updated to use `ansible_os_family` instead of `ansible_distribution` #65 by @xterr
- Added required stuff to use ClickHouse Keeper #64 by @jbuckmccready


### Benefits
- Now the role admits other kind of os_family
- Config compatibility with ClickHouse Keeper

### Possible Drawbacks

Not known / detected

### Applicable Issues

Closes #65 and #64 